### PR TITLE
new function: svgExists(path), ran on heads+tails

### DIFF
--- a/src/utils/engine-client.js
+++ b/src/utils/engine-client.js
@@ -1,6 +1,6 @@
 import { streamAll } from "../io/websocket";
 import { makeQueryString, httpToWsProtocol, join } from "./url";
-import { loadSvgs, getSvg } from "./inline-svg";
+import { loadSvgs, getSvg, svgExists } from "./inline-svg";
 import { isLastFrameOfGame } from "./game-state";
 
 const DEFAULT_SNAKE_HEAD = "regular";
@@ -44,7 +44,7 @@ function getAllSvgs(snakes) {
   return Array.from(unique);
 }
 
-function assignHeadAndTailUrls(snakes) {
+async function assignHeadAndTailUrls(snakes) {
   for (const snake of snakes) {
     // Assign default if missing
     if (!snake.HeadType) {
@@ -57,11 +57,18 @@ function assignHeadAndTailUrls(snakes) {
     // Format as actual URL if it's just a name
     snake.HeadType = getSnakeHeadSvgUrl(snake.HeadType);
     snake.TailType = getSnakeTailSvgUrl(snake.TailType);
+
+    if (!(await svgExists(snake.HeadType))) {
+      snake.HeadType = getSnakeHeadSvgUrl(DEFAULT_SNAKE_HEAD);
+    }
+    if (!(await svgExists(snake.TailType))) {
+      snake.TailType = getSnakeTailSvgUrl(DEFAULT_SNAKE_TAIL);
+    }
   }
 }
 
 async function setHeadAndTailSvgs(snakes) {
-  assignHeadAndTailUrls(snakes);
+  await assignHeadAndTailUrls(snakes);
   await loadSvgs(getAllSvgs(snakes));
 
   for (const snake of snakes) {

--- a/src/utils/inline-svg.js
+++ b/src/utils/inline-svg.js
@@ -20,6 +20,7 @@
  */
 
 const loaded = {};
+const doesntExist = {};
 
 export function loadSvgs(paths) {
   return Promise.all(paths.map(requireSvg));
@@ -49,4 +50,21 @@ function makeDom(svgText) {
   const wrapper = document.createElement("div");
   wrapper.innerHTML = svgText.trim();
   return wrapper.firstChild;
+}
+
+export async function svgExists(path) {
+  if (path in loaded) {
+    return true;
+  }
+  if (path in doesntExist) {
+    return false;
+  }
+  //not cached yet
+  const response = await fetch(path);
+  const svgText = await response.text();
+  const exists = svgText.startsWith('<svg');
+  if (!exists) {
+    doesntExist[path] = true;
+  }
+  return exists;
 }


### PR DESCRIPTION
Simple fix for [https://github.com/BattlesnakeOfficial/board/issues/8](https://github.com/BattlesnakeOfficial/board/issues/8)

Board runs a single set of extra fetches to check if the submitted heads / tails exist as SVGs or not. (have to check by seeing if response.text() starts with "<svg" because by default play.battlesnake.com returns a 200 ok on a non-existent file)