### PR TITLE
Fix small playback controls

### DIFF
--- a/public/index.css
+++ b/public/index.css
@@ -258,3 +258,9 @@ body {
     opacity: 1;
   }
 }
+
+/*icons*/
+.material-icons-inline {
+  font-size: 1.25rem;
+  margin-right: 0.25rem;
+}

--- a/src/components/scoreboard/error-message/ErrorMessage.css
+++ b/src/components/scoreboard/error-message/ErrorMessage.css
@@ -4,8 +4,3 @@
     display: flex;
     align-items: center;
 }
-
-.material-icons {
-    font-size: 1.25rem;
-    margin-right: 0.25rem;
-}

--- a/src/components/scoreboard/error-message/ErrorMessage.jsx
+++ b/src/components/scoreboard/error-message/ErrorMessage.jsx
@@ -22,7 +22,9 @@ const ErrorMessage = props => {
   }
   return (
     <div className="error-message" style={errorColor}>
-      <span className="material-icons">{getIcon(code)}</span>
+      <span className="material-icons material-icons-inline">
+        {getIcon(code)}
+      </span>
       <span>{message}</span>
     </div>
   );

--- a/src/components/scoreboard/status-indicator/StatusIndicator.jsx
+++ b/src/components/scoreboard/status-indicator/StatusIndicator.jsx
@@ -21,7 +21,9 @@ const StatusIndicator = ({ errorMessage = "", clickHandler = () => {} }) => {
   }
   return (
     <div style={style} onClick={clickHandler}>
-      <span className="material-icons">{getIcon(code)}</span>
+      <span className="material-icons material-icons-inline">
+        {getIcon(code)}
+      </span>
     </div>
   );
 };


### PR DESCRIPTION
Looks like react components don't isolate css modules similarly to other reactive libraries. Split up the css style so we have a new style for smaller icons.