### PR TITLE
Refine speed component

### DIFF
--- a/src/components/settings/SettingsPage.jsx
+++ b/src/components/settings/SettingsPage.jsx
@@ -21,6 +21,10 @@ const SettingsPage = () => {
     dispatch(togglePlayButtons("hide"));
   });
 
+  function dispatchSpeedChange(fps) {
+    dispatch(frameRateUpdated(fps));
+  }
+
   return (
     <main className={theme}>
       <section>
@@ -28,7 +32,7 @@ const SettingsPage = () => {
         <div>
           <PlaybackSpeed
             default={playbackSpeed}
-            onChange={e => dispatch(frameRateUpdated(e.target.value))}
+            onChange={dispatchSpeedChange}
           />
         </div>
         <div>

--- a/src/components/settings/playback/PlaybackSpeed.jsx
+++ b/src/components/settings/playback/PlaybackSpeed.jsx
@@ -1,10 +1,26 @@
+import style from "./PlaybackSpeed.module.css";
+
 const PlaybackSpeed = props => {
   return (
-    <select defaultValue={props.default} onChange={props.onChange}>
-      <option value={6}>Slow</option>
-      <option value={10}>Medium</option>
-      <option value={20}>Fast</option>
-    </select>
+    // <select defaultValue={props.default} onChange={props.onChange}>
+    //   <option value={6}>Slow</option>
+    //   <option value={10}>Medium</option>
+    //   <option value={20}>Fast</option>
+    // </select>
+    <div className="input-container">
+      <input
+        type="range"
+        min={1}
+        max={3}
+        value={props.default}
+        onChange={props.onChange}
+      />
+      <div className={style.labels}>
+        <span>Slow</span>
+        <span>Medium</span>
+        <span>Fast</span>
+      </div>
+    </div>
   );
 };
 

--- a/src/components/settings/playback/PlaybackSpeed.jsx
+++ b/src/components/settings/playback/PlaybackSpeed.jsx
@@ -1,19 +1,47 @@
 import style from "./PlaybackSpeed.module.css";
 
+const SLIDER_SLOW = 1;
+const SLIDER_MEDIUM = 2;
+const SLIDER_FAST = 3;
+
+const SPEED_SLOW = 6;
+const SPEED_MEDIUM = 10;
+const SPEED_FAST = 20;
+
+function valueChanged(e, changeHandler) {
+  let fps = SPEED_FAST;
+  const sliderValue = e.target.value;
+
+  if (sliderValue <= SLIDER_SLOW) {
+    fps = SPEED_SLOW;
+  } else if (sliderValue <= SLIDER_MEDIUM) {
+    fps = SPEED_MEDIUM;
+  }
+
+  changeHandler.call(this, fps);
+}
+
+function defaultValueHandler(value) {
+  let defaultValue = SLIDER_FAST;
+
+  if (value <= SPEED_SLOW) {
+    defaultValue = SLIDER_SLOW;
+  } else if (value <= SPEED_MEDIUM) {
+    defaultValue = SLIDER_MEDIUM;
+  }
+
+  return defaultValue;
+}
+
 const PlaybackSpeed = props => {
   return (
-    // <select defaultValue={props.default} onChange={props.onChange}>
-    //   <option value={6}>Slow</option>
-    //   <option value={10}>Medium</option>
-    //   <option value={20}>Fast</option>
-    // </select>
     <div className="input-container">
       <input
         type="range"
-        min={1}
-        max={3}
-        value={props.default}
-        onChange={props.onChange}
+        min={SLIDER_SLOW}
+        max={SLIDER_FAST}
+        value={defaultValueHandler(props.default)}
+        onChange={e => valueChanged(e, props.onChange)}
       />
       <div className={style.labels}>
         <span>Slow</span>

--- a/src/components/settings/playback/PlaybackSpeed.module.css
+++ b/src/components/settings/playback/PlaybackSpeed.module.css
@@ -6,17 +6,16 @@
 
 input[type="range"] {
     appearance: none;
-    width: 100%; /* Full-width */
-    height: 15px; /* Specified height */
-    background: #c3c2ce; /* Grey background */
-    outline: none; /* Remove outline */
-    opacity: 0.7; /* Set transparency (for mouse-over effects on hover) */
-    transition: opacity .2s;/* 0.2 seconds transition on hover */
+    width: 100%;
+    height: 15px;
+    background: #c3c2ce;
+    outline: none;
+    opacity: 0.7;
+    transition: opacity .2s;
 }
 
-/*!* Mouse-over effects *!*/
 input[type="range"]:hover {
-    opacity: 1; /* Fully shown on mouse-over */
+    opacity: 1;
 }
 
 /* THUMB - todo add postcss-input-range to npm script OR use sass to create mixins */
@@ -30,10 +29,8 @@ input[type=range]::-webkit-slider-thumb {
     background: #736cc7;
     cursor: pointer;
     margin-top: 0; /* You need to specify a margin in Chrome, but in Firefox and IE it is automatic */
-    /* box-shadow: 1px 1px 1px #000000, 0px 0px 1px #0d0d0d; Add cool effects to your sliders! */
 }
 
-/*!* All the same stuff for Firefox *!*/
 input[type=range]::-moz-range-thumb {
     appearance: none;
     width: 36px;
@@ -44,9 +41,8 @@ input[type=range]::-moz-range-thumb {
     cursor: pointer;
 }
 
-/*!* All the same stuff for IE *!*/
 input[type=range]::-ms-thumb {
-    box-shadow: 1px 1px 1px #000000, 0px 0px 1px #0d0d0d;
+    box-shadow: 1px 1px 1px #000000, 0 0 1px #0d0d0d;
     border: 1px solid #000000;
     height: 36px;
     width: 16px;
@@ -63,5 +59,4 @@ input[type="range"]::-moz-range-progress {
 
 input[type="range"]::-ms-fill-lower {
     background-color: #736cc7;
-    /*height: 15px;*/
 }

--- a/src/components/settings/playback/PlaybackSpeed.module.css
+++ b/src/components/settings/playback/PlaybackSpeed.module.css
@@ -19,7 +19,6 @@ input[type="range"]:hover {
 }
 
 /* THUMB - todo add postcss-input-range to npm script OR use sass to create mixins */
-/* Special styling for WebKit/Blink */
 input[type=range]::-webkit-slider-thumb {
     appearance: none;
     width: 36px;

--- a/src/components/settings/playback/PlaybackSpeed.module.css
+++ b/src/components/settings/playback/PlaybackSpeed.module.css
@@ -1,0 +1,67 @@
+.labels {
+    display: flex;
+    justify-content: space-between;
+    margin: 1rem 0;
+}
+
+input[type="range"] {
+    appearance: none;
+    width: 100%; /* Full-width */
+    height: 15px; /* Specified height */
+    background: #c3c2ce; /* Grey background */
+    outline: none; /* Remove outline */
+    opacity: 0.7; /* Set transparency (for mouse-over effects on hover) */
+    transition: opacity .2s;/* 0.2 seconds transition on hover */
+}
+
+/*!* Mouse-over effects *!*/
+input[type="range"]:hover {
+    opacity: 1; /* Fully shown on mouse-over */
+}
+
+/* THUMB - todo add postcss-input-range to npm script OR use sass to create mixins */
+/* Special styling for WebKit/Blink */
+input[type=range]::-webkit-slider-thumb {
+    appearance: none;
+    width: 36px;
+    height: 36px;
+    border-radius: 50%;
+    border: 1px solid #ffffff;
+    background: #736cc7;
+    cursor: pointer;
+    margin-top: 0; /* You need to specify a margin in Chrome, but in Firefox and IE it is automatic */
+    /* box-shadow: 1px 1px 1px #000000, 0px 0px 1px #0d0d0d; Add cool effects to your sliders! */
+}
+
+/*!* All the same stuff for Firefox *!*/
+input[type=range]::-moz-range-thumb {
+    appearance: none;
+    width: 36px;
+    height: 36px;
+    border-radius: 50%;
+    border: 1px solid #ffffff;
+    background: #736cc7;
+    cursor: pointer;
+}
+
+/*!* All the same stuff for IE *!*/
+input[type=range]::-ms-thumb {
+    box-shadow: 1px 1px 1px #000000, 0px 0px 1px #0d0d0d;
+    border: 1px solid #000000;
+    height: 36px;
+    width: 16px;
+    border-radius: 3px;
+    background: #ffffff;
+    cursor: pointer;
+}
+
+/* Style track colour before & after thumb - not supported in chrome */
+input[type="range"]::-moz-range-progress {
+    background-color: #736cc7;
+    height: 15px;
+}
+
+input[type="range"]::-ms-fill-lower {
+    background-color: #736cc7;
+    /*height: 15px;*/
+}


### PR DESCRIPTION
Re-introducing the slider component with better styling and snap support.
Rather than use the actual framerate value for the slider, opted to translate the framerate value to a value to represent 1 of 3 speeds for the slider. This is done to:
* implement a snap to behaviour more easily
* allow the labels to appear evenly spaced. Since the actual speed values aren't evenly spaced, using the actual values caused labels that appeared incorrectly spaced.