### PR TITLE
Removed theme class from settings page.

### DIFF
--- a/src/components/settings/SettingsPage.jsx
+++ b/src/components/settings/SettingsPage.jsx
@@ -29,7 +29,7 @@ const SettingsPage = () => {
   }
 
   return (
-    <main className={theme}>
+    <main>
       <section>
         <h2>Playback Settings</h2>
         <fieldset>


### PR DESCRIPTION
Board playback settings are hard to read in 'projector' theme so the themes are no longer applied to the settings page.