### PR TITLE
Change settings speeds

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ http://127.0.0.1:3000/?engine=[ENGINE_URL]&game=[GAME_ID]
 #### Optional
 - `autoplay` - start game playback immediately. Values true / false. Defaults to false.
 - `boardTheme` - the theme of the board. Values dark / light. Defaults to light.
-- `frameRate` - the maximum frame rate used for playback. Takes an integer value equal to FPS. Defaults to 10 FPS.
+- `frameRate` - the maximum frame rate used for playback. Takes an integer value equal to FPS. Defaults to 6 FPS. (medium speed)
 - `hideScoreboard` - remove the scoreboard for embedding cool games. Values true false. Defaults to false.
 - `hideMediaControls` - remove the controls for embedding cool games. Values true / false. Defaults to false.
 - `loop` - restart playback immediately once game completes. Values true / false. Defaults to false.

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -1,13 +1,14 @@
 import { delay, getFrameByTurn, streamAllEvents } from "../utils/engine-client";
 import * as types from "./action-types";
+import { DEFAULT_FRAMERATE } from "../components/settings/defaults";
 
-// Sort of a hack, until we have persisted playback options
-let DEFAULT_FPS = 10;
-try {
-  DEFAULT_FPS = localStorage.getItem("frameRate") || 10;
-} catch (err) {
-  console.log("unable to load localStorage");
-}
+// // Sort of a hack, until we have persisted playback options
+// let DEFAULT_FPS = 6;
+// try {
+//   DEFAULT_FPS = localStorage.getItem("frameRate") || DEFAULT_FPS;
+// } catch (err) {
+//   console.log("unable to load localStorage");
+// }
 
 export const setGameOptions = gameOptions => ({
   type: types.SET_GAME_OPTIONS,
@@ -118,7 +119,7 @@ export const playFromFrame = frame => {
     const frameIndex = frames.indexOf(frame);
     const slicedFrames = frames.slice(frameIndex);
 
-    const ceiledFps = Math.ceil(frameRate || DEFAULT_FPS);
+    const ceiledFps = Math.ceil(frameRate || DEFAULT_FRAMERATE);
     const delayMillis = 1000 / ceiledFps;
 
     for (const frame of slicedFrames) {

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -2,14 +2,6 @@ import { delay, getFrameByTurn, streamAllEvents } from "../utils/engine-client";
 import * as types from "./action-types";
 import { DEFAULT_FRAMERATE } from "../components/settings/defaults";
 
-// // Sort of a hack, until we have persisted playback options
-// let DEFAULT_FPS = 6;
-// try {
-//   DEFAULT_FPS = localStorage.getItem("frameRate") || DEFAULT_FPS;
-// } catch (err) {
-//   console.log("unable to load localStorage");
-// }
-
 export const setGameOptions = gameOptions => ({
   type: types.SET_GAME_OPTIONS,
   gameOptions

--- a/src/app/storage.js
+++ b/src/app/storage.js
@@ -1,3 +1,8 @@
+import {
+  DEFAULT_FRAMERATE,
+  initialSettings
+} from "../components/settings/defaults";
+
 export function storageAvailable(type) {
   let storage;
   try {
@@ -41,14 +46,14 @@ export function rehydrateLocalSettings() {
   let checkAutoplay = getLocalSetting("autoplay");
 
   if (typeof checkAutoplay === "undefined") {
-    checkAutoplay = true; // default to true
+    checkAutoplay = initialSettings.autoplay;
   } else {
     checkAutoplay = checkAutoplay === "true";
   }
 
   return {
-    frameRate: Number(getLocalSetting("frameRate")) || 10,
-    theme: getLocalSetting("theme") || "light",
+    frameRate: Number(getLocalSetting("frameRate")) || DEFAULT_FRAMERATE,
+    theme: getLocalSetting("theme") || initialSettings.theme,
     autoplay: checkAutoplay
   };
 }

--- a/src/app/store.js
+++ b/src/app/store.js
@@ -3,6 +3,7 @@ import rootReducer from "../reducers";
 import settingsReducer, {
   settingsStoreListener
 } from "../components/settings/settings-slice";
+import { initialSettings } from "../components/settings/defaults";
 import { themes } from "../theme";
 import { rehydrateLocalSettings, storageAvailable } from "./storage";
 
@@ -18,12 +19,7 @@ function rehydrateInitialState() {
       highlightedSnake: null,
       theme: themes.light
     },
-    settings: {
-      frameRate: 20,
-      theme: "light",
-      autoplay: false,
-      persistAvailable: false
-    }
+    settings: initialSettings
   };
 
   if (storageAvailable("localStorage")) {

--- a/src/components/settings/defaults.js
+++ b/src/components/settings/defaults.js
@@ -1,0 +1,10 @@
+import { themes } from "../../theme";
+
+export const DEFAULT_FRAMERATE = 6;
+
+export const initialSettings = {
+  frameRate: DEFAULT_FRAMERATE,
+  theme: themes.light,
+  autoplay: false,
+  persistAvailable: false
+};

--- a/src/components/settings/playback/PlaybackSpeed.jsx
+++ b/src/components/settings/playback/PlaybackSpeed.jsx
@@ -1,12 +1,12 @@
 import style from "./PlaybackSpeed.module.css";
 
-const SLIDER_SLOW = 1;
-const SLIDER_MEDIUM = 2;
-const SLIDER_FAST = 3;
+export const SLIDER_SLOW = 1;
+export const SLIDER_MEDIUM = 2;
+export const SLIDER_FAST = 3;
 
-const SPEED_SLOW = 6;
-const SPEED_MEDIUM = 10;
-const SPEED_FAST = 20;
+export const SPEED_SLOW = 6; // new 3
+export const SPEED_MEDIUM = 10; // new 6
+export const SPEED_FAST = 20;
 
 function valueChanged(e, changeHandler) {
   let fps = SPEED_FAST;

--- a/src/components/settings/playback/PlaybackSpeed.jsx
+++ b/src/components/settings/playback/PlaybackSpeed.jsx
@@ -1,16 +1,23 @@
 import style from "./PlaybackSpeed.module.css";
+import { DEFAULT_FRAMERATE } from "../defaults";
 
 export const SLIDER_SLOW = 1;
 export const SLIDER_MEDIUM = 2;
 export const SLIDER_FAST = 3;
 
-export const SPEED_SLOW = 6; // new 3
-export const SPEED_MEDIUM = 10; // new 6
+export const SPEED_SLOW = 3;
+export const SPEED_MEDIUM = DEFAULT_FRAMERATE;
 export const SPEED_FAST = 20;
+
+const speedRanges = {
+  SPEED_SLOW: { min: 0, max: 5 },
+  SPEED_MEDIUM: { min: 6, max: 12 },
+  SPEED_FAST: { min: 13, max: 20 }
+};
 
 function valueChanged(e, changeHandler) {
   let fps = SPEED_FAST;
-  const sliderValue = e.target.value;
+  const sliderValue = e.target.valueAsNumber || e.target.value;
 
   if (sliderValue <= SLIDER_SLOW) {
     fps = SPEED_SLOW;
@@ -22,12 +29,12 @@ function valueChanged(e, changeHandler) {
 }
 
 function defaultValueHandler(value) {
-  let defaultValue = SLIDER_FAST;
+  let defaultValue = SLIDER_MEDIUM;
 
-  if (value <= SPEED_SLOW) {
+  if (value <= speedRanges.SPEED_SLOW.max) {
     defaultValue = SLIDER_SLOW;
-  } else if (value <= SPEED_MEDIUM) {
-    defaultValue = SLIDER_MEDIUM;
+  } else if (value > speedRanges.SPEED_MEDIUM.max) {
+    defaultValue = SLIDER_FAST;
   }
 
   return defaultValue;

--- a/src/components/settings/playback/PlaybackSpeed.jsx
+++ b/src/components/settings/playback/PlaybackSpeed.jsx
@@ -10,7 +10,7 @@ export const SPEED_MEDIUM = DEFAULT_FRAMERATE;
 export const SPEED_FAST = 20;
 
 const speedRanges = {
-  SPEED_SLOW: { min: 0, max: 5 },
+  SPEED_SLOW: { min: 1, max: 5 },
   SPEED_MEDIUM: { min: 6, max: 12 },
   SPEED_FAST: { min: 13, max: 20 }
 };

--- a/src/components/settings/playback/PlaybackSpeed.test.js
+++ b/src/components/settings/playback/PlaybackSpeed.test.js
@@ -1,13 +1,61 @@
 import React from "react";
 import { render, screen } from "@testing-library/react";
 
-import PlaybackSpeed, { SLIDER_MEDIUM } from "./PlaybackSpeed";
+import PlaybackSpeed, {
+  SLIDER_FAST,
+  SLIDER_MEDIUM,
+  SLIDER_SLOW
+} from "./PlaybackSpeed";
 
-it("renders with or without a default speed", () => {
-  render(<PlaybackSpeed />);
+describe("renders with or without a default speed", () => {
+  it("uses medium as default when no value provided", () => {
+    render(<PlaybackSpeed />);
 
-  const speedSlider = screen.getByRole("slider");
+    const speedSlider = screen.getByRole("slider");
 
-  expect(speedSlider).toBeInTheDocument();
-  expect(speedSlider).toHaveValue(SLIDER_MEDIUM);
+    expect(speedSlider).toBeInTheDocument();
+    expect(speedSlider).toHaveValue(String(SLIDER_MEDIUM));
+  });
+
+  it("renders the supplied value as default", () => {
+    render(<PlaybackSpeed default={1} />);
+
+    const speedSlider = screen.getByRole("slider");
+
+    expect(speedSlider).toHaveValue(String(SLIDER_SLOW));
+  });
+
+  it("uses a default within range if supplied value is larger than max range", () => {
+    render(<PlaybackSpeed default={30} />);
+
+    const speedSlider = screen.getByRole("slider");
+
+    expect(Number(speedSlider.value)).toBeGreaterThanOrEqual(SLIDER_SLOW);
+    expect(Number(speedSlider.value)).toBeLessThanOrEqual(SLIDER_FAST);
+  });
+
+  it("uses a default within range if supplied value is less than min range", () => {
+    render(<PlaybackSpeed default={-1} />);
+
+    const speedSlider = screen.getByRole("slider");
+
+    expect(Number(speedSlider.value)).toBeGreaterThanOrEqual(SLIDER_SLOW);
+    expect(Number(speedSlider.value)).toBeLessThanOrEqual(SLIDER_FAST);
+  });
+});
+
+describe("renders the correct speed", () => {
+  test.each([
+    [1, SLIDER_SLOW],
+    [5, SLIDER_SLOW],
+    [6, SLIDER_MEDIUM],
+    [12, SLIDER_MEDIUM],
+    [13, SLIDER_FAST],
+    [20, SLIDER_FAST]
+  ])("framerate: %i", (fps, expected) => {
+    render(<PlaybackSpeed default={fps} />);
+    const speedSlider = screen.getByRole("slider");
+
+    expect(speedSlider).toHaveValue(String(expected));
+  });
 });

--- a/src/components/settings/playback/PlaybackSpeed.test.js
+++ b/src/components/settings/playback/PlaybackSpeed.test.js
@@ -1,0 +1,13 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+
+import PlaybackSpeed, { SLIDER_MEDIUM } from "./PlaybackSpeed";
+
+it("renders with or without a default speed", () => {
+  render(<PlaybackSpeed />);
+
+  const speedSlider = screen.getByRole("slider");
+
+  expect(speedSlider).toBeInTheDocument();
+  expect(speedSlider).toHaveValue(SLIDER_MEDIUM);
+});

--- a/src/components/settings/playback/PlaybackSpeed.test.js
+++ b/src/components/settings/playback/PlaybackSpeed.test.js
@@ -1,10 +1,13 @@
 import React from "react";
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 
 import PlaybackSpeed, {
   SLIDER_FAST,
   SLIDER_MEDIUM,
-  SLIDER_SLOW
+  SLIDER_SLOW,
+  SPEED_FAST,
+  SPEED_MEDIUM,
+  SPEED_SLOW
 } from "./PlaybackSpeed";
 
 describe("renders with or without a default speed", () => {
@@ -58,4 +61,25 @@ describe("renders the correct speed", () => {
 
     expect(speedSlider).toHaveValue(String(expected));
   });
+});
+
+describe("sends the correct framerate to callback when slider value changes", () => {
+  test.each([
+    [SPEED_FAST, SLIDER_SLOW, SPEED_SLOW],
+    [SPEED_SLOW, SLIDER_MEDIUM, SPEED_MEDIUM],
+    [SPEED_MEDIUM, SLIDER_FAST, SPEED_FAST]
+  ])(
+    "currentFramerate: %i, selectedSpeed: %i, framerate: %i",
+    (currentFramerate, sliderSpeed, fps) => {
+      const speedChangedCallback = jest.fn();
+      const { getByRole } = render(
+        <PlaybackSpeed
+          default={currentFramerate}
+          onChange={speedChangedCallback}
+        />
+      );
+      fireEvent.change(getByRole("slider"), { target: { value: sliderSpeed } });
+      expect(speedChangedCallback).toHaveBeenCalledWith(fps);
+    }
+  );
 });

--- a/src/components/settings/settings-slice.js
+++ b/src/components/settings/settings-slice.js
@@ -1,17 +1,10 @@
 import { createSlice } from "@reduxjs/toolkit";
 import { getLocalSetting, setLocalSetting } from "../../app/storage";
-import { themes } from "../../theme";
-
-const initialState = {
-  frameRate: 20,
-  theme: themes.light,
-  autoplay: false,
-  persistAvailable: false
-};
+import { initialSettings } from "./defaults";
 
 export const settingsSlice = createSlice({
   name: "settings",
-  initialState,
+  initialSettings,
   reducers: {
     frameRateUpdated(state, action) {
       state.frameRate = action.payload;

--- a/src/components/settings/settings-slice.js
+++ b/src/components/settings/settings-slice.js
@@ -1,10 +1,10 @@
 import { createSlice } from "@reduxjs/toolkit";
 import { getLocalSetting, setLocalSetting } from "../../app/storage";
-import { initialSettings } from "./defaults";
+import { initialSettings as initialState } from "./defaults";
 
 export const settingsSlice = createSlice({
   name: "settings",
-  initialSettings,
+  initialState,
   reducers: {
     frameRateUpdated(state, action) {
       state.frameRate = action.payload;

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -1,0 +1,1 @@
+import "@testing-library/jest-dom";


### PR DESCRIPTION
The slow speed isn't feeling quite right so we're adjusting the values:  
- SLOW: 3fps (old 6fps)
- MEDIUM: 6fps (old 10fps)
- FAST: 20 fps (no change)

This change is not fully backwards compatible since any previously saved slow speed will now display as medium in the settings form. It won't affect the playback though.

To add more confidence in our components a new test file was added for the PlaybackSpeed component.
Tests verify that the correct framerate is sent when a new speed is selected in the settings form AND the slider will display the correct speed using a range of values. This will improve backwards compatibility with previous settings that are saved to localStorage.  
- SLOW: 1 - 5 (previous 6)
- MEDIUM: 6 - 12 (previous 10)
- FAST: 13 - 20 (previous 20)

Also includes some cleanup. The default settings values are now defined in one place and imported where needed.
