### PR TITLE
DEV-1798: Pause playback when settings page is opened, and don't reload frames afterwards

### DIFF
--- a/src/components/game.jsx
+++ b/src/components/game.jsx
@@ -101,15 +101,19 @@ class Game extends React.Component {
       this.props.toggleTheme(options.theme);
     }
 
-    if (options.game && options.engine) {
-      this.hideLogo = options.hideLogo === "true";
-      this.hideScoreboard = options.hideScoreboard === "true";
-      this.showFrameScrubber = options.showFrameScrubber;
-      this.title = options.title && decodeURIComponent(options.title);
-      this.props.setGameOptions(options);
-      this.props.fetchFrames();
-    } else {
+    if (!(options.game && options.engine)) {
       this.invalidArgs = true;
+      return;
+    }
+
+    this.hideLogo = options.hideLogo === "true";
+    this.hideScoreboard = options.hideScoreboard === "true";
+    this.showFrameScrubber = options.showFrameScrubber;
+    this.title = options.title && decodeURIComponent(options.title);
+    this.props.setGameOptions(options);
+
+    if (this.props.frames.length === 0) {
+      this.props.fetchFrames();
     }
   }
 

--- a/src/components/settings/SettingsPage.jsx
+++ b/src/components/settings/SettingsPage.jsx
@@ -13,7 +13,7 @@ import {
 import PlaybackSpeed from "./playback/PlaybackSpeed";
 import styles from "./SettingsPage.module.css";
 import { useHistory } from "react-router-dom";
-import { togglePlayButtons, themeChanged } from "../../actions";
+import { togglePlayButtons, pauseGame, themeChanged } from "../../actions";
 
 const SettingsPage = () => {
   const history = useHistory();
@@ -25,6 +25,7 @@ const SettingsPage = () => {
 
   useEffect(() => {
     dispatch(togglePlayButtons("hide"));
+    dispatch(pauseGame());
   });
 
   function dispatchSpeedChange(fps) {


### PR DESCRIPTION
This fixes a bug where opening the settings page while the game was currently playing and then changing the frame rate would result in skipping between turns.

It also avoids reloading the frames when the settings page is closed - this broke the browser preview in the CLI because it can only serve them once.