### PR TITLE
Add `local` engine to read playback frames from NDJSON files.

### DIFF
--- a/src/routes/replays/[id]/+server.ts
+++ b/src/routes/replays/[id]/+server.ts
@@ -1,0 +1,30 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import type { RequestHandler } from "./$types";
+
+const ROOT_DIR = process.env.REPLAYS_DIR ?? process.cwd();
+
+export const GET: RequestHandler = async ({ params }) => {
+  // Load the local NDJSON 'replay' file.
+  // TODO(schoon): Once we decide on a real extension, use that here.
+  // Check that the file exists, and return a 404 otherwise.
+  const replayFile = await readFile(join(ROOT_DIR, `${params.id}.ndjson`), "utf-8");
+  const replayLines = replayFile.split("\n").filter((line) => line.trim().length);
+
+  // TODO(schoon): This would be much better with a clear delimiter,
+  // not just a gentlemen's agreement that the first line is special.
+  const info = JSON.parse(replayLines[0]);
+  const frames = replayLines.slice(1).map((line) => JSON.parse(line));
+
+  return new Response(
+    JSON.stringify({
+      frames,
+      info
+    }),
+    {
+      headers: {
+        "Content-Type": "application/json"
+      }
+    }
+  );
+};


### PR DESCRIPTION
This reads the new playback-optimized replay files from `rules`, given the `engine` setting of `"local"`. Files are, by default, read from `process.cwd()`, but can be read from another location via the `REPLAYS_DIR` environment variable.

In other words, asking for `?game=1234&engine=local` will read from `${REPLAYS_DIR}/1234.ndjson`.

Requested feedback (also left as TODO comments in context, in case we intend to address these in the future):
- [ ] Do we have a file extension we would like to use in place of the not-quite-standard `.ndjson`?
- [ ] Alongside that, do we want a delimiter between the first "game info" JSON line, and the frame lines? We could break with NDJSON and use `---` like it's front matter, or use a JSON-compatible value like the empty object, `{}`.